### PR TITLE
README.md에서 npm publish 배지 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Last update](https://img.shields.io/npm/last-update/%40libertygame%2Ftypes)](https://www.npmjs.com/package/@libertygame/types)
 [![Issues](https://img.shields.io/github/issues/LibertygameWikiKorea/libertygame-types?logo=github)](https://github.com/LibertygameWikiKorea/libertygame-types/issues)
 [![Pull Requests](https://img.shields.io/github/issues-pr/LibertygameWikiKorea/libertygame-types?logo=github)](https://github.com/LibertygameWikiKorea/libertygame-types/pulls)
-[![npm publish](https://github.com/LibertygameWikiKorea/libertygame-types/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/LibertygameWikiKorea/libertygame-types/actions/workflows/npm-publish.yml)
 
 [리버티게임](https://libertyga.me)에서 사용하는 스크립트를 타입스크립트로도 개발할 수 있도록 전역 함수 및 변수나 소도구의 타입 정의를 배포합니다.
 


### PR DESCRIPTION
워크플로 개선(#42)으로 일반적인 상황에서는 npm publish 워크플로가 중간단계이거나 직접 실행되지 않으므로 불필요해짐.